### PR TITLE
Use official method to add pypy ppa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,10 @@ CMD ["/sbin/my_init"]
 
 VOLUME /srv/graphite
 
-RUN echo 'deb http://ppa.launchpad.net/pypy/ppa/ubuntu trusty main' >> /etc/apt/sources.list
-RUN echo 'deb-src http://ppa.launchpad.net/pypy/ppa/ubuntu trusty main' >> /etc/apt/sources.list
+RUN sudo add-apt-repository -y ppa:pypy/ppa
 RUN apt-get update && apt-get upgrade -y
 
-RUN apt-get install -y language-pack-en python-virtualenv libcairo2-dev
-# unauthenticated..
-RUN apt-get install -y --force-yes pypy
+RUN apt-get install -y language-pack-en python-virtualenv libcairo2-dev pypy
 
 ENV LANGUAGE en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ CMD ["/sbin/my_init"]
 
 VOLUME /srv/graphite
 
-RUN sudo add-apt-repository -y ppa:pypy/ppa
+RUN add-apt-repository -y ppa:pypy/ppa
 RUN apt-get update && apt-get upgrade -y
 
 RUN apt-get install -y language-pack-en python-virtualenv libcairo2-dev pypy


### PR DESCRIPTION
Using the `add-apt-repository` command imports the PGP keys as well, enabling us to install verified, secure `pypy`.